### PR TITLE
Fix mac NotImplementedError when pressing P

### DIFF
--- a/src/renderer.py
+++ b/src/renderer.py
@@ -1831,12 +1831,17 @@ class RendererProcess:
                             (info_bg_rect.x + info_width - 10, y_offset - 1))
             
             # Metrics data in two columns
+            try:
+                queue_size = f"{self.logic_to_render_queue.qsize()}"
+            except NotImplementedError:
+                queue_size = "N/A (macOS)"
+
             metrics = [
                 ("FPS", f"{current_fps:.1f}"),
                 ("Frame Time", f"{avg_frame_time*1000:.1f} ms"),
                 ("Entities", f"{len(self.entities)}"),
                 ("Particles", f"{len(self.projectile_particles) + len(self.explosion_particles)}"),
-                ("Queue Size", f"{self.logic_to_render_queue.qsize()}")
+                ("Queue Size", queue_size)
             ]
             
             # System metrics if available


### PR DESCRIPTION
Fixes issue where game crashes when pressing the 'P' Key. Issue was Queue.qsize() not being usable on MacOS (it doesn't have the functionality to retrieve the queue size). 

Added a try/except block to handle error and provide an alternative value for queue size (see attached image).

Fixes issue #3.
<img width="1195" alt="image" src="https://github.com/user-attachments/assets/49b71d62-80ea-4792-acb3-6320ea6a08eb" />
